### PR TITLE
Fix issue with video player controls and page titles

### DIFF
--- a/src/lib/blocks/Blog.svelte
+++ b/src/lib/blocks/Blog.svelte
@@ -45,10 +45,6 @@
     });
   });
 
-  onDestroy(() => {
-    metadata.reset();
-  });
-
   $: if (pageNum) loadPosts();
 </script>
 

--- a/src/lib/components/VideoPlayer.svelte
+++ b/src/lib/components/VideoPlayer.svelte
@@ -106,11 +106,9 @@
     }
   });
 
-  $: {
-    if (paused) {
-      showControls = true;
-      clearTimeout(showControlsTimeout);
-    }
+  $: if (userPaused) {
+    showControls = true;
+    clearTimeout(showControlsTimeout);
   }
 </script>
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -20,10 +20,6 @@
             author: siteAuthor,
         });
     });
-
-    onDestroy(() => {
-        metadata.reset();
-    });
 </script>
 
 <svelte:head>


### PR DESCRIPTION
- Solved an issue in the `VideoPlayer.svelte` component, that makes the controls visible by default unless the video is hovered. 
- Solved an issue with page metadata being reset and not updated when going from the home page to the blog and back. 