### PR TITLE
Fix color of extraContent to match general theming

### DIFF
--- a/src/lib/blocks/ContentBlock.svelte
+++ b/src/lib/blocks/ContentBlock.svelte
@@ -169,7 +169,7 @@
 
   {#if $$slots.extraContent || extraContent}
     <div
-      class={`text-center max-w-2xl mx-auto px-8 mt-8 prose prose-h2:text-lg prose-h1:text-xl prose-headings:font-light
+      class={`text-center max-w-2xl mx-auto px-8 mt-8 prose prose-h2:text-xl prose-headings:font-light
               prose-headings:tracking-tight prose-headings:text-gray-700 prose-headings:dark:text-neutral-300
               prose-p:font-light prose-p:text-base prose-p:text-gray-700 prose-p:dark:text-gray-300
               ${columns ? 'order-first' : ''}`}

--- a/src/lib/blocks/ContentBlock.svelte
+++ b/src/lib/blocks/ContentBlock.svelte
@@ -169,10 +169,10 @@
 
   {#if $$slots.extraContent || extraContent}
     <div
-      class={`text-center max-w-2xl mx-auto px-8 mt-8 prose prose-h2:text-xl prose-headings:font-light prose-headings:tracking-tight
-              prose-headings:text-neutral-700 prose-headings:dark:text-neutral-300
+      class={`text-center max-w-2xl mx-auto px-8 mt-8 prose prose-h2:text-lg prose-h1:text-xl prose-headings:font-light
+              prose-headings:tracking-tight prose-headings:text-gray-700 prose-headings:dark:text-neutral-300
               prose-p:font-light prose-p:text-base prose-p:text-gray-700 prose-p:dark:text-gray-300
-        ${columns ? 'order-first' : ''}`}
+              ${columns ? 'order-first' : ''}`}
     >
       {#if $$slots.extraContent}
         <slot name="extraContent" />


### PR DESCRIPTION
Change the color of the `extraContent` section to match the color of the main theme.