### PR TITLE
Fix Windows and macOS download URLs

### DIFF
--- a/src/lib/config/index.js
+++ b/src/lib/config/index.js
@@ -104,11 +104,11 @@ export const releases = {
   mac: {
     arm64: {
       name: "macOS (M1)",
-      link: "https://github.com/spyder-ide/spyder/releases/latest/download/Spyder_arm64.dmg",
+      link: "https://github.com/spyder-ide/spyder/releases/latest/download/Spyder-macOS-arm64.pkg",
     },
     x64: {
       name: "macOS (Intel)",
-      link: "https://github.com/spyder-ide/spyder/releases/latest/download/Spyder.dmg",
+      link: "https://github.com/spyder-ide/spyder/releases/latest/download/Spyder-macOS-x86_64.pkg",
     },
   },
 };

--- a/src/lib/config/index.js
+++ b/src/lib/config/index.js
@@ -98,7 +98,7 @@ export const releases = {
   windows: {
     x64: {
       name: "Windows 10+",
-      link: "https://github.com/spyder-ide/spyder/releases/latest/download/Spyder_64bit_full.exe",
+      link: "https://github.com/spyder-ide/spyder/releases/latest/download/Spyder-Windows-x86_64.exe",
     },
   },
   mac: {


### PR DESCRIPTION
The URL to the Windows and Mac installers were wrong.